### PR TITLE
Enabling sync for STDOUT so output is written as soon as it is sent.

### DIFF
--- a/lib/dandelion.rb
+++ b/lib/dandelion.rb
@@ -2,7 +2,8 @@ module Dandelion
   class << self
     def logger
       return @log if @log
-      @log = Logger.new(STDOUT)
+      $stdout.sync = true
+      @log = Logger.new($stdout)
       @log.level = Logger::DEBUG
       @log.formatter = formatter
       @log


### PR DESCRIPTION
We use a little wrapper around dandelion written in PHP to change the API slightly for our developers and make things a bit more streamline for our deployment process. We use PHP's `system` function to pipe the output of dandelion into STDOUT.

However, I've noticed that when dandelion's logger is called, the writes are buffered until the entire transfer has taken place, this makes our wrapper script feel a bit unresponsive.

This PR turns on syncing when writing to STDOUT so that output is written as soon as the logger methods are called. This should have negligible impact on performance as dandelion will never create huge amounts of output in normal use.
