### PR TITLE
Dandelion supports transferring additional files that are not checked into the git repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Git repository is searched for a file named `dandelion.yml`). Example:
         - .gitignore
         - dandelion.yml
     revision_file: .revision
+    additional:
+          - public/css/print.css
+          - public/css/screen.css
+          - public/js/main.js
 
 Schemes
 -------

--- a/lib/dandelion/command.rb
+++ b/lib/dandelion/command.rb
@@ -118,7 +118,7 @@ module Dandelion
         begin
           backend ||= backend()
           revision_file = @config['revision_file'].nil? ? '.revision' : @config['revision_file']
-          options = { :exclude => @config['exclude'], :revision => revision, :revision_file => revision_file, :dry => @options[:dry] }
+          options = { :exclude => @config['exclude'], :additional => @config['additional'], :revision => revision, :revision_file => revision_file, :dry => @options[:dry] }
           Deployment::Deployment.create(@repo, backend, options)
         rescue Git::DiffError
           log.fatal('Error: could not generate diff')

--- a/lib/dandelion/deployment.rb
+++ b/lib/dandelion/deployment.rb
@@ -19,7 +19,7 @@ module Dandelion
       def initialize(repo, backend, options = {})
         @repo = repo
         @backend = backend
-        @options = { :exclude => [], :revision => 'HEAD', :revision_file => '.revision' }.merge(options)
+        @options = { :exclude => [], :additional => [], :revision => 'HEAD', :revision_file => '.revision' }.merge(options)
         @tree = Git::Tree.new(@repo, @options[:revision])
         
         if @options[:dry]
@@ -80,15 +80,30 @@ module Dandelion
           deploy_changed
           deploy_deleted
         else
-          log.debug("Nothing to deploy")
+          log.debug("No changes to deploy")
         end
         unless revisions_match?
           write_revision
         end
+        deploy_additional
       end
-    
+
+      def deploy_additional
+
+        if @options[:additional].empty?
+          log.debug("No additional files to deploy")
+          return
+        end
+
+        @options[:additional].each do |file|
+            log.debug("Uploading additional file: #{file}")
+            @backend.write(file, file)
+          end
+      end
+
       def deploy_changed
         @diff.changed.each do |file|
+          p file
           if exclude_file?(file)
             log.debug("Skipping file: #{file}")
           else

--- a/lib/dandelion/git.rb
+++ b/lib/dandelion/git.rb
@@ -1,3 +1,4 @@
+require 'rubygems'
 require 'grit'
 
 module Dandelion


### PR DESCRIPTION
Love Dandelion. We use grunt in our build process to lint/minify our JS and CSS and prefer that the compiled files do not have to live in the repository. This patch adds an 'additional' section to the config file for files that will be transferred every time 'deploy' is run.

Please let me know if you require any changes to the patch to accept it into master.

Thank you!
