### PR TITLE
Dandelion supports transferring additional files not in the git repo

### DIFF
--- a/lib/dandelion/deployment.rb
+++ b/lib/dandelion/deployment.rb
@@ -103,7 +103,6 @@ module Dandelion
 
       def deploy_changed
         @diff.changed.each do |file|
-          p file
           if exclude_file?(file)
             log.debug("Skipping file: #{file}")
           else

--- a/lib/dandelion/git.rb
+++ b/lib/dandelion/git.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'grit'
 
 module Dandelion


### PR DESCRIPTION
This patch allows users to spec a list of additional files in their dandelion.yml, such as:

additional:
- public/css/ie.css
- public/css/print.css
- public/css/admin.css

These files will then always be transferred once the tree sync is complete.
