### PR TITLE
Updating readme for more possible use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ There is support for multiple backend file transfer adapters.  The configuration
 must specify one of these adapters and the set of additional parameters required
 by the given adapter.
 
-**SFTP**: `adapter: sftp` *(honors ssh config files, allowing public key auth)*
+**SFTP**: `adapter: sftp` *(honors [ssh config
+files](http://www.howtogeek.com/75007/stupid-geek-tricks-use-your-ssh-config-file-to-create-aliases-for-hosts/))*
 
 Required:
 


### PR DESCRIPTION
No documentation indicated that output when using `-h` changed based on the placement. For instance:

```
$ dandelion -h deploy
Usage: dandelion [options] <command> [<args>]
    -v, --version                    Display the current version
    -h, --help                       Display this screen
        --repo=[REPO]                Use the given repository
        --config=[CONFIG]            Use the given configuration file

  Available commands:
      deploy
      status
```

and

```
$ dandelion deploy -h
Usage dandelion deploy [options] [<revision>]
    --dry-run                       Show what would have been deployed
```

This also indicates `--dry-run` as an option when using `deploy`, which was highly valuable as I was getting ready to submit a pull request with this feature when I noticed it already existed.

SSH public key auth went undocumented so a note was added to the SFTP adapter to indicate how it was possible. This also provides more context for why the `password` param is sometimes optional.
