### PR TITLE
Updating dependency on rugged

### DIFF
--- a/dandelion.gemspec
+++ b/dandelion.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
 !   additional gems need to be installed.
   MSG
 
-  s.add_dependency 'rugged', '~> 0.19.0'
+  s.add_dependency 'rugged', '>= 0.19.0'
 end


### PR DESCRIPTION
As of June 2014, rugged gem was bumped up to v0.21.0 and still works. This gem was reported to not have up-to-date dependencies.
