### PR TITLE
Add option to preserve symlinks

### DIFF
--- a/lib/dandelion/adapter/noop.rb
+++ b/lib/dandelion/adapter/noop.rb
@@ -9,6 +9,9 @@ module Dandelion
 
       def delete(path)
       end
+
+      def symlink(path, data)
+      end
     end
   end
 end

--- a/lib/dandelion/adapter/sftp.rb
+++ b/lib/dandelion/adapter/sftp.rb
@@ -55,6 +55,19 @@ module Dandelion
         end
       end
 
+      def symlink(file, target)
+        begin
+          @sftp.symlink!(target, path(file))
+        rescue Net::SFTP::StatusException => e
+          if e.code == 2
+            mkdir_p(File.dirname(path(file)))
+          else
+            @sftp.remove!(path(file))
+          end
+          @sftp.symlink!(target, path(file))
+        end
+      end
+
       def to_s
         "sftp://#{@config['username']}@#{@config['host']}/#{@config['path']}"
       end

--- a/lib/dandelion/change.rb
+++ b/lib/dandelion/change.rb
@@ -1,6 +1,7 @@
 module Dandelion
   class Change
     attr_reader :path, :type
+    attr_accessor :type
     
     def initialize(path, type, read = nil)
       @path = path

--- a/lib/dandelion/changeset.rb
+++ b/lib/dandelion/changeset.rb
@@ -24,6 +24,7 @@ module Dandelion
           if change.type == :delete
             yield Change.new(path, change.type)
           else
+            change.type = :symlink if @tree.is_symlink?(change.path)
             read = -> { @tree.data(change.path) }
             yield Change.new(path, change.type, read)
           end

--- a/lib/dandelion/deployer.rb
+++ b/lib/dandelion/deployer.rb
@@ -50,6 +50,13 @@ module Dandelion
       when :delete
         log.debug("Deleting file: #{change.path}")  
         @adapter.delete(change.path)
+      when :symlink
+        if @adapter.respond_to?(:symlink)
+          log.debug("Creating symlink: #{change.path}")
+          @adapter.symlink(change.path, change.data)
+        else
+          log.debug("Skipped creating symlink:  #{change.path} -> #{change.data}")
+        end
       end
     end
 

--- a/spec/dandelion/changeset_spec.rb
+++ b/spec/dandelion/changeset_spec.rb
@@ -70,4 +70,30 @@ describe Dandelion::Changeset do
       end
     end
   end
+
+  context 'diff adds symlink' do
+    let(:changeset) { test_changeset_with_symlinks }
+
+    describe '#enumerable' do
+      let(:changes) { changeset.to_a }
+
+      it 'returns all changes' do
+        expect(changes).to be_a(Array)
+        expect(changes.length).to eq 1
+        expect(changes.map(&:path)).to eq ['link']
+        expect(changes.map(&:type)).to eq [:symlink]
+      end
+
+      it 'returns data for write changes' do
+        expect(changes.select { |c| c.type != :delete }.map(&:data)).to eq ["baz/bar"]
+      end
+    end
+
+    describe '#empty?' do
+      it 'returns false' do
+        expect(changeset.empty?).to eq false
+      end
+    end
+  end
+
 end

--- a/spec/dandelion/tree_spec.rb
+++ b/spec/dandelion/tree_spec.rb
@@ -16,8 +16,8 @@ describe Dandelion::Tree do
       let(:repo) { test_repo('repo_symlink') }
       let(:tree) { test_tree(repo: repo, commit: repo.lookup('4c19bbe7ba04230a0ae2281c1abbc48a76a66550')) }
 
-      it 'returns content of link source path' do
-        expect(tree.data('link')).to eq "bar\n"
+      it 'returns target path of the symlink' do
+        expect(tree.data('link')).to eq "baz/bar"
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,14 @@ def test_changeset(options = {})
   Dandelion::Changeset.new(test_tree, test_commits.first, options)
 end
 
+def test_changeset_with_symlinks(options = {})
+  repo = test_repo('repo_symlink')
+  commit0 = repo.lookup('3d9b743acb4a84dd99002d2c6f3fcf1a47e9f06b')
+  commit1 = repo.lookup('4c19bbe7ba04230a0ae2281c1abbc48a76a66550')
+  tree = test_tree(repo: repo, commit: commit1)
+  Dandelion::Changeset.new(tree, commit0, options)
+end
+
 def test_diff
   test_changeset.diff
 end


### PR DESCRIPTION
Previous behaviour was to resolve each symlink locally, and reupload the referenced files. However, this fails if a symlink points to a directory. For me, the desired behaviour is to make no attempt to resolve symlinks, and preserve them in their original form by creating identical symlinks on the remote computer.

This behaviour can now be enabled by setting preserve_symlinks to true in the config file. By default, the behaviour should be unchanged though. Currently only the SFTP adapter is supported by this parameter, though it should be possible to make it work for others too.

Apologies for the large changeset; please let me know if anything should be implemented differently.