### PR TITLE
Fixes issue with error reporting when default config files are missing

### DIFF
--- a/lib/dandelion/cli.rb
+++ b/lib/dandelion/cli.rb
@@ -88,7 +88,7 @@ module Dandelion
           File.join(repo_path, 'dandelion.yaml')
         ]
 
-        paths.drop_while { |path| !path || !File.exists?(path) }.first
+        paths.drop_while { |path| !path || !File.exists?(path) }.first || paths.first
       end
     end
 


### PR DESCRIPTION
If neither of the `dandelion.yml` or `dandelion.yaml` default config files are present and no explicit `--config` option is set, dandelion `0.4.14` is throwing a ruby error instead of the intended error message:

    $ mkdir test 
    $ cd test
    $ git init
    $ dandelion status
    /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/dandelion-0.4.14/lib/dandelion/cli.rb:116:in `exists?': no implicit conversion of nil into String (TypeError)
      from /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/dandelion-0.4.14/lib/dandelion/cli.rb:116:in `validate!'
      from /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/dandelion-0.4.14/lib/dandelion/cli.rb:65:in `execute!'
      from /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/dandelion-0.4.14/bin/dandelion:8:in `<top (required)>'
      from /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bin/dandelion:23:in `load'
      from /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bin/dandelion:23:in `<main>'
    $ dandelion init
    /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/dandelion-0.4.14/lib/dandelion/cli.rb:116:in `exists?': no implicit conversion of nil into String (TypeError)
      from /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/dandelion-0.4.14/lib/dandelion/cli.rb:116:in `validate!'
      from /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/dandelion-0.4.14/lib/dandelion/cli.rb:65:in `execute!'
      from /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/dandelion-0.4.14/bin/dandelion:8:in `<top (required)>'
      from /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bin/dandelion:23:in `load'
      from /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bin/dandelion:23:in `<main>'

If no explicit option is set and both files are missing `config_path` was returning `nil`, but `validate!` expects a string value.

This changes `config_path` to return the first path as the default when neither are present.

After this change:

    $ dandelion status
    Missing config file: /Users/tom/tmp/dandelion.yml
    $ dandelion init
    Missing config file: /Users/tom/tmp/dandelion.yml