### PR TITLE
S3 cache control

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Required:
 Optional:
 
  * `preserve_permissions` (defaults to true)
+ * `cache_control` (time to cache content in seconds, e.g. '1296000')
+ * `expires` (time to cache content in seconds, e.g. '1296000')
 
 Usage
 -----

--- a/lib/dandelion/adapter/s3.rb
+++ b/lib/dandelion/adapter/s3.rb
@@ -29,8 +29,8 @@ module Dandelion
 
         # Set caching options
         options = {}
-        options.cache_control = "max-age=#{@config[:cache_control]}" if @config[:cache_control]
-        options.expires = @config[:expires] if @config[:expires]
+        options[:cache_control] = "max-age=#{@config[:cache_control]}" if @config[:cache_control]
+        options[:expires] = @config[:expires] if @config[:expires]
 
         AWS::S3::S3Object.store(path(file), data, bucket_name, options)
         AWS::S3::S3Object.acl(key, bucket_name, policy) unless policy.nil?

--- a/lib/dandelion/adapter/s3.rb
+++ b/lib/dandelion/adapter/s3.rb
@@ -27,7 +27,11 @@ module Dandelion
         rescue AWS::S3::NoSuchKey
         end
 
-        AWS::S3::S3Object.store(path(file), data, bucket_name)
+        options = {}
+        options.cache_control = "max-age=#{@config[:cache_control]}" if @config[:cache_control]
+        options.expires = @config[:expires] if @config[:expires]
+
+        AWS::S3::S3Object.store(path(file), data, bucket_name, options)
         AWS::S3::S3Object.acl(key, bucket_name, policy) unless policy.nil?
       end
 

--- a/lib/dandelion/adapter/s3.rb
+++ b/lib/dandelion/adapter/s3.rb
@@ -27,6 +27,7 @@ module Dandelion
         rescue AWS::S3::NoSuchKey
         end
 
+        # Set caching options
         options = {}
         options.cache_control = "max-age=#{@config[:cache_control]}" if @config[:cache_control]
         options.expires = @config[:expires] if @config[:expires]


### PR DESCRIPTION
I made some first minor changes in the S3 adapter to support additional optional parameters "cache_control" and "expires". Until now there was no option so set metadata for S3 files. 