### PR TITLE
Fixes issue with error reporting when directory is not a git repo

### DIFF
--- a/lib/dandelion/cli.rb
+++ b/lib/dandelion/cli.rb
@@ -102,7 +102,7 @@ module Dandelion
 
     def repo_exists?
       return !!(repo)
-    rescue ::IOError, ::Rugged::OSError
+    rescue ::IOError, ::Rugged::OSError, ::Rugged::RepositoryError
       # squash exceptions for instantiating Rugged repo
       return false
     end


### PR DESCRIPTION
If the current directory, or explicitly set target directory (via `--repo`) is not a git repository, dandelion is throwing a ruby error instead of the intended error message:

    $ mkdir tmp 
    $ cd tmp

    $ dandelion status
    /Users/tom/work/github/dandelion/lib/dandelion/cli.rb:33:in `new': Could not find repository from '/Users/tom/Desktop' (Rugged::RepositoryError)
      from /Users/tom/work/github/dandelion/lib/dandelion/cli.rb:33:in `repo'
      from /Users/tom/work/github/dandelion/lib/dandelion/cli.rb:104:in `repo_exists?'
      from /Users/tom/work/github/dandelion/lib/dandelion/cli.rb:111:in `validate!'
      from /Users/tom/work/github/dandelion/lib/dandelion/cli.rb:65:in `execute!'
      from /Users/tom/work/github/dandelion/bin/dandelion:8:in `<top (required)>'
      from /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bin/dandelion:23:in `load'
      from /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bin/dandelion:23:in `<main>'

    $ dandelion --repo="/tmp" status
    /Users/tom/work/github/dandelion/lib/dandelion/cli.rb:33:in `new': Could not find repository from '/Users/tom/Desktop' (Rugged::RepositoryError)
      from /Users/tom/work/github/dandelion/lib/dandelion/cli.rb:33:in `repo'
      from /Users/tom/work/github/dandelion/lib/dandelion/cli.rb:104:in `repo_exists?'
      from /Users/tom/work/github/dandelion/lib/dandelion/cli.rb:111:in `validate!'
      from /Users/tom/work/github/dandelion/lib/dandelion/cli.rb:65:in `execute!'
      from /Users/tom/work/github/dandelion/bin/dandelion:8:in `<top (required)>'
      from /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bin/dandelion:23:in `load'
      from /Users/tom/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/bin/dandelion:23:in `<main>'

`repo_exists?` was set up to rescue `::IOError, ::Rugged::OSError`, but the error being thrown is `::Rugged::RepositoryError`. I've added this to the rescue.

After this change:

    $ dandelion status
    Not a git repository: /Users/tom/tmp
    $ dandelion --repo="/tmp" status
    Not a git repository: /tmp

Gem versions:

    dandelion (0.4.14)
    rugged (0.22.1b1)