### PR TITLE
Feature: Cloudfront invalidation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ end
 group :development do
   gem 'net-sftp'
   gem 'aws-s3'
+  gem 'cloudfront-invalidator'
 end

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Optional:
  * `expires` (time to cache content in seconds, e.g. '1296000')
 
 Additional:
-    It is possible to clear Amazon Cloudfront caches if required parameters are set:
+
+It is possible to clear Amazon Cloudfront caches if required parameters are set:
 
     Required:
         * `cloudfront`

--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ Additional:
 It is possible to clear Amazon Cloudfront caches if required parameters are set:
 
 Required:
-    * `cloudfront`
-    * `distribution` (The distribution ID)
-    * `invalidate` (Can be true or false.)
+* `cloudfront`
+* `distribution` (The distribution ID)
+* `invalidate` (Can be true or false.)
 
 Optional:
-    * `files`
+* `files`
 
 If the parameter `files` is missing the whole cloudfront distribution cache
 will be cleared.

--- a/README.md
+++ b/README.md
@@ -136,18 +136,18 @@ Additional:
 
 It is possible to clear Amazon Cloudfront caches if required parameters are set:
 
-    Required:
-        * `cloudfront`
-        * `distribution` (The distribution ID)
-        * `invalidate` (Can be true or false.)
+Required:
+    * `cloudfront`
+    * `distribution` (The distribution ID)
+    * `invalidate` (Can be true or false.)
 
-    Optional:
-        * `files`
+Optional:
+    * `files`
 
-    If the parameter `files` is missing the whole cloudfront distribution cache
-    will be cleared.
+If the parameter `files` is missing the whole cloudfront distribution cache
+will be cleared.
 
-    Example:
+Example:
 
 ```yaml
 cloudfront:

--- a/README.md
+++ b/README.md
@@ -132,6 +132,32 @@ Optional:
  * `cache_control` (time to cache content in seconds, e.g. '1296000')
  * `expires` (time to cache content in seconds, e.g. '1296000')
 
+Additional:
+    It is possible to clear Amazon Cloudfront caches if required parameters are set:
+
+    Required:
+        * `cloudfront`
+        * `distribution` (The distribution ID)
+        * `invalidate` (Can be true or false.)
+
+    Optional:
+        * `files`
+
+    If the parameter `files` is missing the whole cloudfront distribution cache
+    will be cleared.
+
+    Example:
+
+```yaml
+cloudfront:
+   distribution: "YOUR_DISTRIBUTION"
+   invalidate: true
+   files:
+        - file1
+        - /path/to/file2
+        - file3
+```
+
 Usage
 -----
 


### PR DESCRIPTION
I implemented invalidation functionality for Amazon Cloudfront with the help of a gem: 

https://github.com/reidiculous/cloudfront-invalidator

If you have your S3 bucket in combination with Cloudfront it is sometimes required to invalidate the cache, otherwise old files will be delivered after a deploy is made. 