### PR TITLE
Force deletion deltas to be handled before create/modify deltas

### DIFF
--- a/lib/dandelion/diff.rb
+++ b/lib/dandelion/diff.rb
@@ -34,13 +34,9 @@ private
     end
 
     def each
-      @deltas.each do |delta|
-        if delta.deleted?
-          yield Change.new(delta.old_file[:path], :delete)
-        else
-          yield Change.new(delta.new_file[:path], :write)
-        end
-      end
+      deletes, writes = @deltas.partition(&:deleted?)
+      deletes.each { |delta| yield Change.new(delta.old_file[:path], :delete) }
+      writes.each { |delta| yield Change.new(delta.new_file[:path], :write) }
     end
   end
 

--- a/spec/dandelion/changeset_spec.rb
+++ b/spec/dandelion/changeset_spec.rb
@@ -10,8 +10,8 @@ describe Dandelion::Changeset do
       it 'returns all changes' do
         expect(changes).to be_a(Array)
         expect(changes.length).to eq 5
-        expect(changes.map(&:path)).to eq ['bar', 'baz/bar', 'baz/foo', 'foo', 'qux']
-        expect(changes.map(&:type)).to eq [:delete, :write, :delete, :write, :write]
+        expect(changes.map(&:path)).to eq ['bar', 'baz/foo', 'baz/bar', 'foo', 'qux']
+        expect(changes.map(&:type)).to eq [:delete, :delete, :write, :write, :write]
       end
 
       it 'returns data for write changes' do
@@ -35,12 +35,12 @@ describe Dandelion::Changeset do
       it 'returns all changes' do
         expect(changes).to be_a(Array)
         expect(changes.length).to eq 2
-        expect(changes.map(&:path)).to eq ['bar', 'foo']
-        expect(changes.map(&:type)).to eq [:write, :delete]
+        expect(changes.map(&:path)).to eq ['foo', 'bar']
+        expect(changes.map(&:type)).to eq [:delete, :write]
       end
 
       it 'returns data for write changes' do
-        expect(changes.first.data).to eq "bar\n"
+        expect(changes.last.data).to eq "bar\n"
       end
     end
 


### PR DESCRIPTION
This prevents issues when a diff converts a file/directory/symlink into one of the other types without changing its name.

Eg. The SFTP adapter is being used. A diff simultaneously deletes a directory and creates a normal file with the same name as the old directory. If the deletion is not handled first, the SFTP attempt to create the new file will fail, because a directory with the same name already exists.