### PR TITLE
update rugged to 0.26.0

### DIFF
--- a/dandelion.gemspec
+++ b/dandelion.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
 !   additional gems need to be installed.
   MSG
 
-  s.add_dependency 'rugged', '0.23.3'
+  s.add_dependency 'rugged', '0.26.0'
 end


### PR DESCRIPTION
The older version of rugged was failing to build on Arch linux. Using the newest version resolves the problem.