### PR TITLE
Use native Net::FTP rather than double-bags for FTPS.

### DIFF
--- a/lib/dandelion/adapter/ftp.rb
+++ b/lib/dandelion/adapter/ftp.rb
@@ -19,7 +19,7 @@ module Dandelion
 
       def read(file)
         begin
-          @ftp.getbinaryfile(path(file), nil)
+          @ftp.get(path(file), nil)
         rescue Net::FTPPermError => e
           nil
         end
@@ -28,11 +28,11 @@ module Dandelion
       def write(file, data)
         temp(file, data) do |temp|
           begin
-            @ftp.putbinaryfile(temp, path(file))
+            @ftp.put(temp, path(file))
           rescue Net::FTPPermError => e
             raise e unless e.to_s =~ /550|553/
             mkdir_p(File.dirname(path(file)))
-            @ftp.putbinaryfile(temp, path(file))
+            @ftp.put(temp, path(file))
           end
         end
       end
@@ -54,6 +54,9 @@ module Dandelion
       def ftp_client
         ftp = Net::FTP.new
         ftp.connect(@config['host'], @config['port'])
+        if @config['ascii']
+          ftp.binary=false
+        end
         ftp.login(@config['username'], @config['password'])
         ftp.passive = @config['passive']
         ftp

--- a/lib/dandelion/adapter/ftps.rb
+++ b/lib/dandelion/adapter/ftps.rb
@@ -6,39 +6,36 @@ module Dandelion
       include ::Dandelion::Utils
 
       adapter 'ftps'
-      requires_gems 'double-bag-ftps'
 
       def initialize(config)
-        require 'double_bag_ftps'
-
-        config[:auth_tls] = to_b(config[:auth_tls])
-        config[:ftps_implicit] = to_b(config[:ftps_implicit])
         config[:inscecure] = to_b(config[:insecure])
-
         super(config)
       end
 
     private
 
       def ftp_client
-        ftps = DoubleBagFTPS.new(@config['host'], nil, nil, nil, ftps_mode, {})
-
-        if @config['insecure']
-          ftps.ssl_context = DoubleBagFTPS.create_ssl_context(verify_mode: OpenSSL::SSL::VERIFY_NONE)
+        host = @config['host']
+        ftps = Net::FTP.new(host, connection_params)
+        if @config['ascii']
+            ftps.binary = false
         end
-
-        ftps.login(@config['username'], @config['password'], nil, ftps_auth)
-        ftps.passive = @config[:passive]
-
-        ftps
+        return ftps
       end
 
-      def ftps_auth
-        @config['auth_tls'] ? 'TLS' : nil
+      def connection_params
+        {
+           port: @config['port'],
+           ssl: ssl_context_params,
+           passive: @config['passive'],
+           username: @config['username'],
+           password: @config['password'],
+           debug_mode: @config['debug']
+        }
       end
 
-      def ftps_mode
-        @config['ftps_implicit'] ? DoubleBagFTPS::IMPLICIT : DoubleBagFTPS::EXPLICIT
+      def ssl_context_params
+        @config['insecure'] ? { verify_mode: OpenSSL::SSL::VERIFY_NONE } : nil
       end
     end
   end


### PR DESCRIPTION
It seems as if Net::FTP added TLS support as of ruby 2.4,
which conflicts with double-bags. This switches ftps from
using double-bags to using the native ruby Net::FTP.

I needed support for ascii file transfers, so this also
adds support for that. Luckily this was pretty easy to do.

Warning. This might break implicit ftps. I don't have any
way to test that functionality.

Also, I'm not a ruby programmer. I simply needed this
working in my environment. This could likely be cleaned
up quite a bit.