### PR TITLE
Switch to native Net::FTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Optional:
  * `port` (defaults to 21)
  * `passive` (defaults to false)
 
-**FTPS**: `adapter: ftps` (ftp over TLS, based on [DoubleBagFTPS](https://github.com/bnix/double-bag-ftps) and Dandelions native FTP adapter)
+**FTPS**: `adapter: ftps`
 
 Required: (same as FTP)
 
@@ -120,7 +120,6 @@ Optional: (in addition to options for FTP)
 
  * `port`
  * `passive`
- * `auth_tls` (default false)
  * `ftps_implicit` (default false: explicit TLS)
  * `insecure` (default false, true to allow self-signed certificates)
 

--- a/lib/dandelion/adapter/ftp.rb
+++ b/lib/dandelion/adapter/ftp.rb
@@ -19,7 +19,7 @@ module Dandelion
 
       def read(file)
         begin
-          @ftp.getbinaryfile(path(file), nil)
+          @ftp.get(path(file), nil)
         rescue Net::FTPPermError => e
           nil
         end
@@ -28,11 +28,11 @@ module Dandelion
       def write(file, data)
         temp(file, data) do |temp|
           begin
-            @ftp.putbinaryfile(temp, path(file))
+            @ftp.put(temp, path(file))
           rescue Net::FTPPermError => e
             raise e unless e.to_s =~ /550|553/
             mkdir_p(File.dirname(path(file)))
-            @ftp.putbinaryfile(temp, path(file))
+            @ftp.put(temp, path(file))
           end
         end
       end
@@ -54,6 +54,9 @@ module Dandelion
       def ftp_client
         ftp = Net::FTP.new
         ftp.connect(@config['host'], @config['port'])
+        if @config['ascii']
+          ftp.binary=false
+        end
         ftp.login(@config['username'], @config['password'])
         ftp.passive = @config['passive']
         ftp

--- a/lib/dandelion/adapter/ftps.rb
+++ b/lib/dandelion/adapter/ftps.rb
@@ -6,14 +6,12 @@ module Dandelion
       include ::Dandelion::Utils
 
       adapter 'ftps'
-      requires_gems 'double-bag-ftps'
 
       def initialize(config)
         require 'double_bag_ftps'
 
-        config[:auth_tls] = to_b(config[:auth_tls])
         config[:ftps_implicit] = to_b(config[:ftps_implicit])
-        config[:inscecure] = to_b(config[:insecure])
+        config[:insecure] = to_b(config[:insecure])
 
         super(config)
       end
@@ -21,24 +19,27 @@ module Dandelion
     private
 
       def ftp_client
-        ftps = DoubleBagFTPS.new(@config['host'], nil, nil, nil, ftps_mode, {})
-
-        if @config['insecure']
-          ftps.ssl_context = DoubleBagFTPS.create_ssl_context(verify_mode: OpenSSL::SSL::VERIFY_NONE)
+        host = @config['host']
+        ftps = Net::FTP.new(host, connection_params)
+        if @config['ascii']
+          ftps.binary = false
         end
 
-        ftps.login(@config['username'], @config['password'], nil, ftps_auth)
-        ftps.passive = @config[:passive]
-
-        ftps
+        def connection_params
+          {
+             port: @config['port'],
+             ssl: ssl_context_params,
+             passive: @config['passive'],
+             implicit_ftps: @config['ftps_implicit'],
+             username: @config['username'],
+             password: @config['password'],
+             debug_mode: @config['debug']
+          }
+        
       end
 
-      def ftps_auth
-        @config['auth_tls'] ? 'TLS' : nil
-      end
-
-      def ftps_mode
-        @config['ftps_implicit'] ? DoubleBagFTPS::IMPLICIT : DoubleBagFTPS::EXPLICIT
+      def ssl_context_params
+        @config['insecure'] ? { verify_mode: OpenSSL::SSL::VERIFY_NONE } : true
       end
     end
   end


### PR DESCRIPTION
This MR builds on
- @oldendick [initial fix](https://github.com/scttnlsn/dandelion/pull/166) 
- @ninthspace config [typo fix](https://github.com/ninthspace/dandelion/commit/d895f5d13ae818ab03986bc4c04844c052507f91)

Adding
- Fixes logic issue with `@config['insecure']` ensuring SSL use 
- Allows `implicit_ftps` connection using backwards compatible `@config['ftps_implicit']` 